### PR TITLE
Add reservation utilities and context

### DIFF
--- a/database/schema.py
+++ b/database/schema.py
@@ -68,6 +68,18 @@ CREATE TABLE IF NOT EXISTS Notes (
     FOREIGN KEY (history_id) REFERENCES History(history_id),
     FOREIGN KEY (employee_id) REFERENCES Employees(employee_id) ON DELETE SET NULL
 );
+
+CREATE TABLE IF NOT EXISTS Reservations (
+    reservation_id     SERIAL PRIMARY KEY,
+    client_id          INTEGER NOT NULL,
+    reservation_time   TIMESTAMP NOT NULL,
+    covers             INTEGER NOT NULL,
+    notes_json         JSONB,
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT unique_reservation UNIQUE (client_id, reservation_time),
+    FOREIGN KEY (client_id) REFERENCES Clients(client_id) ON DELETE CASCADE
+);
 """
 
 def initialize_database():

--- a/mcp/mcp_server.py
+++ b/mcp/mcp_server.py
@@ -3,7 +3,9 @@ from manage import app, get_db
 from agents.mcp import mcp_server_fastapi
 from sqlalchemy.orm import Session
 from fastapi import Depends
-import models
+
+from models import client as client_model
+from models import reservations as reservation_model
 
 server = mcp_server_fastapi(app, name="maitred-mcp")
 
@@ -14,7 +16,16 @@ class UpsertReservationIn(BaseModel):
     # Either an existing client_id OR a client_name for new/unknown clients
     client_id: int | None = None
     client_name: str | None = None
-    special_request: str | None = None
+    special_requests: str | None = None
+    occasion: str | None = None
+    seating: str | None = None
+    dietary: str | None = None
+    source: str | None = None
+    language_guess: str | None = None
+    parsed_party_size: int | None = None
+    parsed_date: str | None = None
+    parsed_time: str | None = None
+    created_by_bot: bool = False
 
     @root_validator
     def client_reference_required(cls, values):
@@ -36,7 +47,7 @@ async def upsert_reservation(
 ):
     # Resolve or create client when only a name is supplied
     if data.client_id is None:
-        data.client_id = models.get_or_create_client_id(db, data.client_name)
+        data.client_id = client_model.get_or_create_client_id(data.client_name)
 
     payload = data.dict(exclude={"client_name"})
-    return models.upsert_reservation(db=db, **payload)
+    return reservation_model.upsert_reservation(**payload)

--- a/models/client.py
+++ b/models/client.py
@@ -108,4 +108,19 @@ def update_last_visit(client_id: int) -> bool:
         """, (client_id,))
         conn.commit()
         return cur.rowcount > 0
+
+
+def get_or_create_client_id(full_name: str) -> int:
+    """Retrieve a client_id for ``full_name`` or create a placeholder client."""
+    parts = full_name.strip().split(" ", 1)
+    first_name = parts[0]
+    last_name = parts[1] if len(parts) > 1 else ""
+
+    existing = get_client_by_name(first_name, last_name)
+    if existing:
+        return existing[0]
+
+    # Create a placeholder client with an unknown phone number
+    placeholder_phone = "unknown"
+    return create_client(first_name, last_name, placeholder_phone)
     

--- a/models/reservations.py
+++ b/models/reservations.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any
+import json
+
+from database.connection import connect
+
+UPCOMING_WINDOW_HOURS = 48
+
+
+def upsert_reservation(
+    client_id: int,
+    date: str,
+    time: str,
+    covers: int,
+    occasion: Optional[str] = None,
+    seating: Optional[str] = None,
+    dietary: Optional[str] = None,
+    special_requests: Optional[str] = None,
+    source: Optional[str] = None,
+    language_guess: Optional[str] = None,
+    parsed_party_size: Optional[int] = None,
+    parsed_date: Optional[str] = None,
+    parsed_time: Optional[str] = None,
+    created_by_bot: bool = False,
+) -> int:
+    """Insert or update a reservation record.
+
+    The combination of ``client_id`` and ``reservation_time`` is treated as
+    unique.  If a record already exists for that tuple, the entry is updated
+    rather than duplicated.
+    """
+    reservation_time = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M")
+
+    notes_json: Dict[str, Any] = {
+        "occasion": occasion,
+        "seating": seating,
+        "dietary": dietary,
+        "special_requests": special_requests,
+        "source": source,
+        "language_guess": language_guess,
+        "parsed_party_size": parsed_party_size,
+        "parsed_date": parsed_date,
+        "parsed_time": parsed_time,
+        "created_by_bot": created_by_bot,
+    }
+
+    with connect() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO Reservations (client_id, reservation_time, covers, notes_json)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (client_id, reservation_time)
+            DO UPDATE SET covers = EXCLUDED.covers,
+                          notes_json = EXCLUDED.notes_json,
+                          updated_at = CURRENT_TIMESTAMP
+            RETURNING reservation_id
+            """,
+            (client_id, reservation_time, covers, json.dumps(notes_json)),
+        )
+        reservation_id = cur.fetchone()[0]
+        conn.commit()
+        return reservation_id
+
+
+def get_upcoming_reservation(client_id: int) -> Optional[Dict[str, Any]]:
+    """Return the soonest reservation within the upcoming window.
+
+    Args:
+        client_id: The client to query for.
+
+    Returns:
+        A dictionary with reservation details or ``None`` if no upcoming
+        reservation exists for the client.
+    """
+    now = datetime.utcnow()
+    window_end = now + timedelta(hours=UPCOMING_WINDOW_HOURS)
+
+    with connect() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT reservation_id, client_id, reservation_time, covers, notes_json
+            FROM Reservations
+            WHERE client_id = %s
+              AND reservation_time BETWEEN %s AND %s
+            ORDER BY reservation_time ASC
+            LIMIT 1
+            """,
+            (client_id, now, window_end),
+        )
+        row = cur.fetchone()
+        if not row:
+            return None
+
+        reservation_id, client_id, reservation_time, covers, notes_json = row
+        return {
+            "reservation_id": reservation_id,
+            "client_id": client_id,
+            "reservation_time": reservation_time,
+            "covers": covers,
+            "notes_json": notes_json,
+        }


### PR DESCRIPTION
## Summary
- add Reservations table and model with upsert and upcoming query helpers
- capture structured reservation details in notes_json when creating/updating
- surface upcoming reservations in chat context as FYI lines

## Testing
- ⚠️ `pytest -q` (fails: connection refused to database)


------
https://chatgpt.com/codex/tasks/task_e_68a28f7856fc83208c080620eb777aff